### PR TITLE
[Mock] /api/community 관련 mock api 추가

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,8 +14,9 @@ module.exports = {
   settings: { react: { version: "18.2" } },
   plugins: ["react-refresh"],
   rules: {
+    "no-unused-vars": "warn",
     "react-refresh/only-export-components": [
-      "warn",
+      "off",
       { allowConstantExport: true },
     ],
     "react/react-in-jsx-scope": "off",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,8 +53,7 @@ function Router() {
           {/* <Route path="1" element={<CommunityDetailPage />} /> */}
           <Route path="" element={<CommunityPage content="mainboard" />} />
         </Route>
-        {/* <Route path={"*"} element={<NotFoundPage />} /> */}
-
+        <Route path={"*"} element={<NotFoundPage />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,10 +5,10 @@ import "./index.css";
 
 async function enableMocking() {
   //실서버와 연동시 //return;의 주석 지워서 테스트해주세요
-  return;
-  // if (import.meta.env.MODE !== "development") return;
-  // const { worker } = await import("./mocks/browser");
-  // return worker.start({ onUnhandledRequest: "bypass" });
+  // return;
+  if (import.meta.env.MODE !== "development") return;
+  const { worker } = await import("./mocks/browser");
+  return worker.start({ onUnhandledRequest: "bypass" });
 }
 
 enableMocking().then(() => {

--- a/src/mocks/data/board.json
+++ b/src/mocks/data/board.json
@@ -1,0 +1,56 @@
+[
+    {
+        "board_no": 1,
+        "board_title": "테스트용",
+		"board_content": "게시글 내용",
+        "board_author": "doctor",
+        "disease_code": "A08",
+        "board_date": "2023-11-17T22:27:07.551471",
+        "board_type": 2
+    },
+    {
+        "board_no": 2,
+        "board_title": "테스트용123",
+		"board_content": "게시글 내용",
+        "board_author": "doctor",
+        "disease_code": "A08",
+        "board_date": "2023-11-17T22:27:12.152535",
+        "board_type": 1
+    },
+    {
+        "board_no": 3,
+        "board_title": "공지사항",
+        "board_content": "이건 공지사항이라는 거다...",
+        "board_author": "doctor",
+        "disease_code": "A08",
+        "board_date": "2023-11-17T22:27:07.551471",
+        "board_type": 2
+    },
+    {
+        "board_no": 4,
+        "board_title": "아무튼 테스트임",
+        "board_content": "보드 컨텐츠를 작성하시오.",
+        "board_author": "Lybell",
+        "disease_code": "A08",
+        "board_date": "2023-11-17T22:27:12.152535",
+        "board_type": 1
+    },
+    {
+        "board_no": 5,
+        "board_title": "구름톤",
+        "board_content": "제작자님 제가 영혼을 안 갈아서 만들었습니다",
+        "board_author": "Lybell",
+        "disease_code": "A08",
+        "board_date": "2023-11-17T22:27:07.551471",
+        "board_type": 2
+    },
+    {
+        "board_no": 6,
+        "board_title": "백엔드 개발자님",
+        "board_content": "항상 DB와 데이터 관리와 관계형에 고통받느라고 수고하십니다 많이\n앞으로도 파이팅...",
+        "board_author": "Lybell",
+        "disease_code": "A08",
+        "board_date": "2023-11-17T22:27:12.152535",
+        "board_type": 1
+    }
+]

--- a/src/mocks/data/comment.json
+++ b/src/mocks/data/comment.json
@@ -1,0 +1,38 @@
+[
+    {
+        "board_no": 1,
+        "comment_author": "doctor",
+        "comment_body": "드라군 놀이다!",
+        "comment_date": "2023-11-17T22:49:20.622744"
+    },
+    {
+        "board_no": 1,
+        "comment_author": "Lybell",
+        "comment_body": "드!",
+        "comment_date": "2023-11-17T22:49:20.622745"
+    },
+    {
+        "board_no": 1,
+        "comment_author": "Hayan",
+        "comment_body": "라!",
+        "comment_date": "2023-11-17T22:49:20.622745"
+    },
+    {
+        "board_no": 1,
+        "comment_author": "Hartstein",
+        "comment_body": "군!",
+        "comment_date": "2023-11-17T22:49:20.622745"
+    },
+    {
+        "board_no": 2,
+        "comment_author": "doctor",
+        "comment_body": "댓글 33333",
+        "comment_date": "2023-11-18T08:49:20.622746"
+    },
+    {
+        "board_no": 3,
+        "comment_author": "doctor",
+        "comment_body": "댓글 44444",
+        "comment_date": "2023-11-18T09:52:20.622747"
+    }
+]


### PR DESCRIPTION
## 수행 태스크
- 커뮤니티 관련 mock api를 추가했습니다. 클라이언트에서 요청을 띄우면 실서버를 오염시키지 않고도 테스트해볼 수 있습니다.
  - 개발의 편의성을 위해 개발에서도 mock api로 다시 요청을 보내도록 했습니다. 물론 빌드 후 프로덕션에서는 msw가 동작을 안 할 거에요.
- eslint 설정을 수정했습니다.
```json
"no-unused-vars": "warn",
"react-refresh/only-export-components": [
  "off",
  { "allowConstantExport": true },
],
```
여러분들 관용적으로 `import React from "react";`를 쓰거나, 아니면 향후 쓸 목적으로 더미 변수를 선언할 때 이전에는 얄짤없이 eslint에서 에러를 뱉었었는데, 이제는 경고만 뱉습니다. 경고 보시고 수정하시면 됩니다.
추가로 여러 컴포넌트를 반환하도록 코드를 짜도 에러가 나지 않습니다.

## mock api 테스트 방법
개발서버를 띄워놓고 개발자 도구에서 다음을 쳐 주세요.
- `fetch("/api/community/board").then(e=>e.json()).then(console.log)` : 게시글 목록이 반환됩니다.
```javascript
fetch("/api/community/write", { 
  type:"POST", body:JSON.stringify({
      "board_title": "테스트용",
      "board_content": "게시글 내용",
      "disease_code": "123",
      "board_type": "1"
  })
}).then(e=>e.json()).then(console.log)
```
새로운 게시글을 추가합니다.